### PR TITLE
travis iojs.x support and update nan explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 node_js:
   - "iojs"
+  - "iojs-2"
+  - "iojs-1"
   - "0.12"
   - "0.11"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^1.7.0"
+    "nan": "^1.8.0"
   }
 }


### PR DESCRIPTION
This commit enables iojs-1 and iojs-2 explicitly for Travis-CI, because
it should work fine on both. Also, update nan in `package.json` to 1.8.0
(which is unnecessary, strictly speaking, because we already use the
caret).

No release is necessary as this is mostly just for Travis-CI.
Ref: [iojs/io.js#1620](https://github.com/iojs/io.js/issues/1620)
